### PR TITLE
service-mesh: update IPs to within default range

### DIFF
--- a/service-mesh/deploy/Vagrantfile
+++ b/service-mesh/deploy/Vagrantfile
@@ -3,7 +3,7 @@
 #
 
 LINUX_BASE_BOX = "bento/ubuntu-18.04"
-LINUX_IP_ADDRESS = "10.199.0.200"
+LINUX_IP_ADDRESS = "192.168.56.200"
 
 Vagrant.configure(2) do |config|
 	serverName = "consul-server"
@@ -11,11 +11,11 @@ Vagrant.configure(2) do |config|
 	productName = "product-api"
 	publicName = "public-api"
 	frontendName = "frontend"
-	serverIP = "10.199.0.10"
-	databaseIP = "10.199.0.20"
-	productIP = "10.199.0.30"
-	publicIP = "10.199.0.40"
-	frontendIP = "10.199.0.50"
+	serverIP = "192.168.56.10"
+	databaseIP = "192.168.56.20"
+	productIP = "192.168.56.30"
+	publicIP = "192.168.56.40"
+	frontendIP = "192.168.56.50"
 
 	config.vm.define serverName, autostart: true, primary: true do |vmCfg|
 		vmCfg.vm.box = LINUX_BASE_BOX


### PR DESCRIPTION
Walking through https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy-vms?in=consul/developer-mesh without this change, I hit the following error:
```
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 10.199.0.20
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly
```

There could be a different way to address this (and I'm unsure if the default range may be different for alternative VM provisioners or platforms (I was using VirtualBox on macOS), but applying this change to the `Vagrantfile` allowed me to continue through the rest of the guide.